### PR TITLE
Exclude .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+# User-specific locally generated configurations
 .vscode
+.idea
 
 /target
 /reports


### PR DESCRIPTION
Importance: Sharing different local user-generated configurations for IntelliJ might cause errors when applied in different IntelliJ environments.